### PR TITLE
Use signed reads for window rectangle

### DIFF
--- a/src/main/index.js
+++ b/src/main/index.js
@@ -390,10 +390,10 @@ function sendKey (keyID) {
 
 function RectPointerToRect (rectPointer) {
   const rect = {};
-  rect.left = rectPointer.readUInt32LE(0);
-  rect.top = rectPointer.readUInt32LE(4);
-  rect.right = rectPointer.readUInt32LE(8);
-  rect.bottom = rectPointer.readUInt32LE(12);
+  rect.left = rectPointer.readInt32LE(0);
+  rect.top = rectPointer.readInt32LE(4);
+  rect.right = rectPointer.readInt32LE(8);
+  rect.bottom = rectPointer.readInt32LE(12);
   return rect;
 }
 


### PR DESCRIPTION
## Summary
- handle negative coordinates by reading window rectangle values as signed ints

## Testing
- `node - <<'NODE' ... NODE`
- `npm test` *(fails: sh: 1: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_689b46d29b4c8326b9277e2daca13a66